### PR TITLE
:art: Remove trailing whitespaces from file headers

### DIFF
--- a/projects/python/generate-qrcode/_main.py
+++ b/projects/python/generate-qrcode/_main.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" 
+"""
 @software: PyCharm
 @author: Lionel Johnson
 @contact: https://fairy.host

--- a/projects/python/generate-qrcode/gui/_run.py
+++ b/projects/python/generate-qrcode/gui/_run.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" 
+"""
 @software: PyCharm
 @author: Lionel Johnson
 @contact: https://fairy.host

--- a/projects/python/generate-qrcode/web/_run.py
+++ b/projects/python/generate-qrcode/web/_run.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" 
+"""
 @software: PyCharm
 @author: Lionel Johnson
 @contact: https://fairy.host

--- a/projects/python/python-demo/rabbitmq_utils.py
+++ b/projects/python/python-demo/rabbitmq_utils.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" 
+"""
 @software: PyCharm
 @author: Lionel Johnson
 @contact: https://fairy.host

--- a/scripts/run-mysql.py
+++ b/scripts/run-mysql.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" 
+"""
 @software: PyCharm
 @author: Lionel Johnson
 @contact: https://fairy.host


### PR DESCRIPTION
These trailing whitespaces were likely added accidentally and aren't needed. They've been removed from several Python file headers across multiple projects to maintain consistent formatting and improve readability.